### PR TITLE
feat(migrate-cli): add --post-display-mode option to show filename in…

### DIFF
--- a/packages/migrate-cli/README.md
+++ b/packages/migrate-cli/README.md
@@ -35,6 +35,7 @@ npx @transnail/migrate-cli [options]
 | `-a` | `--asset-dirname` | Assets directory name (e.g., `assets`, `images`) |
 | `-i` | `--input-dir` | Input directory relative to base path |
 | `-o` | `--output-dir` | Output directory relative to base path |
+| `-p` | `--post-display-mode` | Display mode for post selection: `title` (default, requires front-matter) or `filename` |
 
 ### Examples
 
@@ -44,21 +45,24 @@ npx @transnail/migrate-cli \
   --base="./my-blog" \
   --asset-dirname="assets" \
   --input-dir="./posts" \
-  --output-dir="./migrated"
+  --output-dir="./migrated" \
+  --post-display-mode="title"
 
 # Using short parameters
 npx @transnail/migrate-cli \
   -b "./my-blog" \
   -a "assets" \
   -i "./posts" \
-  -o "./migrated"
+  -o "./migrated" \
+  -p "title"
 
 # With absolute paths
 npx @transnail/migrate-cli \
   --base="/Users/username/blog" \
   --asset-dirname="images" \
   --input-dir="content" \
-  --output-dir="output"
+  --output-dir="output" \
+  --post-display-mode="title"
 ```
 
 ## How It Works

--- a/packages/migrate-cli/dev/index.ts
+++ b/packages/migrate-cli/dev/index.ts
@@ -1,4 +1,5 @@
 import main from "../src/main";
+import { PostDisplayType } from "../src/types";
 
 (async () => {
   await main(
@@ -6,5 +7,6 @@ import main from "../src/main";
     '/home/isaac/Workspace',
     'blog/source/_drafts',
     'blog/source/_posts',
+    PostDisplayType.FileName,
   );
 })();

--- a/packages/migrate-cli/docs/README.zh-CN.md
+++ b/packages/migrate-cli/docs/README.zh-CN.md
@@ -35,6 +35,7 @@ npx @transnail/migrate-cli [选项]
 | `-a` | `--asset-dirname` | 资源目录名称（如 `assets`、`images`） |
 | `-i` | `--input-dir` | 相对于基础路径的输入目录 |
 | `-o` | `--output-dir` | 相对于基础路径的输出目录 |
+| `-p` | `--post-display-mode` | 文章列表显示模式：`title`（默认，需文章包含 front-matter）或 `filename` |
 
 ### 使用示例
 
@@ -44,21 +45,24 @@ npx @transnail/migrate-cli \
   --base="./my-blog" \
   --asset-dirname="assets" \
   --input-dir="./posts" \
-  --output-dir="./migrated"
+  --output-dir="./migrated" \
+  --post-display-mode="title"
 
 # 使用简写参数
 npx @transnail/migrate-cli \
   -b "./my-blog" \
   -a "assets" \
   -i "./posts" \
-  -o "./migrated"
+  -o "./migrated" \
+  -p "title"
 
 # 使用绝对路径
 npx @transnail/migrate-cli \
   --base="/Users/username/blog" \
   --asset-dirname="images" \
   --input-dir="content" \
-  --output-dir="output"
+  --output-dir="output" \
+  --post-display-mode="title"
 ```
 
 ## 工作原理

--- a/packages/migrate-cli/index.ts
+++ b/packages/migrate-cli/index.ts
@@ -1,6 +1,7 @@
 import main from "./src/main";
 import minimist from "minimist";
 import { resolve } from "node:path";
+import { PostDisplayType } from "./src/types";
 
 const args = minimist(process.argv.slice(2), {
   string: [
@@ -8,16 +9,23 @@ const args = minimist(process.argv.slice(2), {
     'asset-dirname',
     'input-dir',      // relative to base
     'output-dir',     // relative to base
+    'post-display-mode',
   ],
   alias: {
     'base': ['b'],
     'input-dir': ['i', 'inputDir'],
     'output-dir': ['o', 'outputDir'],
     'asset-dirname': ['a', 'assetDirName'],
+    'post-display-mode': ['p', 'postDisplayType'],
   },
 });
 
 const { inputDir, outputDir, assetDirName } = args;
 const baseAbsPath = resolve(args.base);
 
-main(assetDirName, baseAbsPath, inputDir, outputDir);
+let postDisplayType = PostDisplayType.Title;
+if ([PostDisplayType.FileName, PostDisplayType.Title].includes(args.postDisplayType.trim())) {
+  postDisplayType = args.postDisplayType.trim();
+}
+
+main(assetDirName, baseAbsPath, inputDir, outputDir, postDisplayType);

--- a/packages/migrate-cli/src/main.ts
+++ b/packages/migrate-cli/src/main.ts
@@ -4,13 +4,15 @@ import Prompt from "./prompt";
 import fg from 'fast-glob';
 import { readFrontMatterTitle } from "./utils";
 import Hint from "./hint";
-import { join } from "node:path";
+import { basename, join } from "node:path";
+import { PostDisplayType } from "./types";
 
 export default async function main(
   assetDirName: string,
   baseAbsPath: string,
   inputDir: string,
   outputDir: string,
+  postDisplayType: PostDisplayType,
 ) {
   const inputDirAbs = join(baseAbsPath, inputDir);
   const outputDirAbs = join(baseAbsPath, outputDir);
@@ -21,10 +23,16 @@ export default async function main(
       cwd: inputDirAbs,
     });
 
+    const getTitle = postDisplayType === PostDisplayType.FileName
+      ? (fullPath: string) => basename(fullPath)
+      : (fullPath: string) => {
+        const { title } = readFrontMatterTitle(fullPath);
+        return title;
+      };
     for (const segement of filePaths) {
       const fullPath = join(inputDirAbs, segement);
-      const { error, title } = readFrontMatterTitle(fullPath);
-      if (!error && title) {
+      const title = getTitle(fullPath);
+      if (title) {
         result.push({ title, postPath: fullPath })
       }
     }

--- a/packages/migrate-cli/src/types.ts
+++ b/packages/migrate-cli/src/types.ts
@@ -14,3 +14,8 @@ export enum TransferModeType {
   Replace = 'replace',
   Skip = 'skip',
 }
+
+export enum PostDisplayType {
+  Title = 'title',
+  FileName = 'filename',
+}


### PR DESCRIPTION
… post selection

- Add -p/--post-display-mode flag with title (default) and filename values
- Title mode requires front-matter in markdown files
- Filename mode displays file names as fallback when front-matter is missing